### PR TITLE
Added basic methods for angular-xeditable editable-form

### DIFF
--- a/angular-xeditable/angular-xeditable.d.ts
+++ b/angular-xeditable/angular-xeditable.d.ts
@@ -53,4 +53,46 @@ declare namespace angular.xeditable {
          */
         activationEvent: string;
     }
+    
+    interface IEditableForm extends angular.IFormController {
+
+        /**
+         * Shows form with editable controls.
+         */
+        $show();
+
+        /**
+         * Hides form with editable controls without saving.
+         */
+        $hide();
+
+        /**
+         * Sets focus on form field specified by `name`.<br/>
+         * When trying to set the focus on a form field of a new row in the editable table, the `$activate` call needs to be wrapped in a `$timeout` call so that the form is rendered before the `$activate` function is called.
+         * 
+         * @param name name of field
+         */
+        $activate(name: string);
+
+        /**
+         * Triggers `oncancel` event and calls `$hide()`.
+         */
+        $cancel();
+
+        $setWaiting(value: boolean);
+
+        /**
+         * Shows error message for particular field.
+         * 
+         * @param name name of field
+         * @param msg error message
+         */
+        $setError(name: string, msg: string);
+
+        $submit();
+
+        $save();
+
+    }    
+    
 }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes. https://github.com/vitalets/angular-xeditable/blob/master/src/js/editable-form/controller.js
